### PR TITLE
ci: change lint workflow to run for each root package

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -12,20 +12,43 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  list-directories:
+    name: List root package directories
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v3.4.0
+      - id: set-matrix
+        run: |
+          PATHS=$(find . -maxdepth 2 -type f -name go.mod -printf '"%h",')
+          echo "matrix=[${PATHS%?}]" >> $GITHUB_OUTPUT
+
   lint:
-    name: Lint Go Code
+    name: 'Lint Go Code: ${{ matrix.package-directory }}'
     runs-on: ubuntu-latest
     timeout-minutes: 6
+    needs: list-directories
+    strategy:
+      matrix:
+        package-directory: ${{ fromJson(needs.list-directories.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v3.4.0
       - uses: technote-space/get-diff-action@v6.1.2
         with:
           PATTERNS: |
             **/*.go
-            */go.mod
-            */go.sum
+            **/go.mod
+            **/go.sum
+      - uses: actions/setup-go@v4
+        if: env.GIT_DIFF
+        with:
+          go-version: '1.21'
       - uses: golangci/golangci-lint-action@v3
+        if: env.GIT_DIFF
         with:
           version: v1.52.1
+          install-mode: goinstall
           args: --timeout 10m
           github-token: ${{ secrets.github_token }}
+          working-directory: ${{ matrix.package-directory }}


### PR DESCRIPTION
Workflow doesn't use the `golangci-lint` binary but instead it installs it using the pre-installed Go version. This is done to avoid using a pre-compiled binary which would cause an issue with the patch version in go mod introduced by Go v1.21.

Resolves #5