### PR TITLE
docs: improve Hermes start command reference

### DIFF
--- a/hermes/README.md
+++ b/hermes/README.md
@@ -24,7 +24,7 @@ ignite relayer hermes configure "mars-1" "http://localhost:26649" "http://localh
 
 - start the relayer
 ```shell
-ignite relayer hermes start [chain-a-id] [chain-a-rpc] [flags]
+ignite relayer hermes start [chain-a-id] [chain-b-id] [flags]
 ```
 e.g.:
 ```shell


### PR DESCRIPTION
On starting the relayer, the example lists 

`ignite relayer hermes start [chain-a-id] [chain-b-id]` 

so this would be reflected in this PR