### PR TITLE
docs: update README in Hermes app

### DIFF
--- a/hermes/README.md
+++ b/hermes/README.md
@@ -10,7 +10,7 @@ The app adds `ignite relayer hermes` commands to allow IBC communication between
 
 - add the hermes relayer app:
 ```shell
-ignite app add -g ($GOPATH)/src/github.com/ignite/apps/hermes
+ignite app install -g ($GOPATH)/src/github.com/ignite/apps/hermes
 ```
 
 - configure the relayer:


### PR DESCRIPTION
It's not `ignite app add` anymore but `ignite app install`