### PR TITLE
chore: add `--path` flag to health monitor app

### DIFF
--- a/examples/health-monitor/cmd/cmd.go
+++ b/examples/health-monitor/cmd/cmd.go
@@ -20,6 +20,12 @@ func GetCommands() []*plugin.Command {
 							Type:         plugin.FlagTypeBool,
 						},
 						{
+							Name:         "path",
+							Usage:        "path of the app",
+							DefaultValue: ".",
+							Type:         plugin.FlagTypeString,
+						},
+						{
 							Name:         "refresh-duration",
 							Shorthand:    "r",
 							Usage:        "refresh duration of the monitor",

--- a/examples/health-monitor/go.mod
+++ b/examples/health-monitor/go.mod
@@ -2,8 +2,6 @@ module health-monitor
 
 go 1.21.1
 
-toolchain go1.21.6
-
 require (
 	github.com/cometbft/cometbft v0.38.5
 	github.com/cosmos/cosmos-sdk v0.50.3


### PR DESCRIPTION
This flag allows users to optionally specify the location of the app chain directory