### PR TITLE
feat: put hermes under root cmd

### DIFF
--- a/hermes/cmd/hermes.go
+++ b/hermes/cmd/hermes.go
@@ -8,15 +8,26 @@ const (
 	flagConfig = "config"
 )
 
+// NewRelayer creates a new Relayer command that holds
+func NewRelayer() *cobra.Command {
+	root := &cobra.Command{
+		Use:           "relayer [command]",
+		Aliases:       []string{"r"},
+		Short:         "Connect blockchains with an IBC relayer",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	root.AddCommand(NewHermes())
+	return root
+}
+
 // NewHermes creates a new Hermes relayer command that holds
 // some other sub commands related to hermes relayer.
 func NewHermes() *cobra.Command {
 	c := &cobra.Command{
-		Use:           "hermes [command]",
-		Aliases:       []string{"h"},
-		Short:         "Hermes relayer wrapper",
-		SilenceUsage:  true,
-		SilenceErrors: true,
+		Use:     "hermes [command]",
+		Aliases: []string{"h"},
+		Short:   "Hermes relayer wrapper",
 	}
 
 	// configure flags.

--- a/hermes/main.go
+++ b/hermes/main.go
@@ -14,16 +14,18 @@ type app struct{}
 
 func (app) Manifest(context.Context) (*plugin.Manifest, error) {
 	m := &plugin.Manifest{Name: "hermes"}
-	m.ImportCobraCommand(cmd.NewHermes(), "ignite")
+	m.ImportCobraCommand(cmd.NewRelayer(), "ignite")
 	return m, nil
 }
 
 func (app) Execute(_ context.Context, c *plugin.ExecutedCommand, _ plugin.ClientAPI) error {
-	// Run the "hermes" command as if it were a root command. To do
-	// so remove the first two arguments which are "ignite"
-	// from OSArgs to treat "hermes" as the root command.
+	// Instead of a switch on c.Use, we run the root command like if
+	// we were in a command line context. This implies to set os.Args
+	// correctly.
+	// Remove the first arg "ignite" from OsArgs because our hermes
+	// command root is "relayer" not "ignite".
 	os.Args = c.OsArgs[1:]
-	return cmd.NewHermes().Execute()
+	return cmd.NewRelayer().Execute()
 }
 
 func (app) ExecuteHookPre(context.Context, *plugin.ExecutedHook, plugin.ClientAPI) error {

--- a/hermes/main.go
+++ b/hermes/main.go
@@ -14,15 +14,15 @@ type app struct{}
 
 func (app) Manifest(context.Context) (*plugin.Manifest, error) {
 	m := &plugin.Manifest{Name: "hermes"}
-	m.ImportCobraCommand(cmd.NewHermes(), "ignite relayer")
+	m.ImportCobraCommand(cmd.NewHermes(), "ignite")
 	return m, nil
 }
 
 func (app) Execute(_ context.Context, c *plugin.ExecutedCommand, _ plugin.ClientAPI) error {
 	// Run the "hermes" command as if it were a root command. To do
-	// so remove the first two arguments which are "ignite relayer"
+	// so remove the first two arguments which are "ignite"
 	// from OSArgs to treat "hermes" as the root command.
-	os.Args = c.OsArgs[2:]
+	os.Args = c.OsArgs[1:]
 	return cmd.NewHermes().Execute()
 }
 

--- a/tools/debug/main.go
+++ b/tools/debug/main.go
@@ -35,7 +35,7 @@ func main() {
 
 	// Add apps with cobra commands.
 	rootCmd.AddCommand(
-		hermes.NewHermes(),
+		hermes.NewRelayer(),
 		marketplace.NewMarketplace(),
 		wasm.NewWasm(),
 		// Add cobra commands for debugging here.


### PR DESCRIPTION
## Description

since we are removing the ts-relayer, the `ignite relayer` command will not exist and will break the hermes app