### PR TITLE
chore: disable hermes integration tests till the CLI V29

### DIFF
--- a/hermes/integration/app_test.go
+++ b/hermes/integration/app_test.go
@@ -215,6 +215,8 @@ func runChain(
 }
 
 func TestHermes(t *testing.T) {
+	t.Skip("skip till the cli V29 to avoid relayer command conflicts")
+
 	var (
 		env         = envtest.New(t)
 		app         = env.Scaffold("github.com/apps/hermes-app")


### PR DESCRIPTION
## Description

Disable Hermes integration tests till the CLI V29 to avoid relayer command conflicts.