### PR TITLE
feat(spaceship): improve logs

### DIFF
--- a/spaceship/CHANGELOG.md
+++ b/spaceship/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Spaceship App Changelog
 
+## [`v0.1.1`](https://github.com/ignite/apps/releases/tag/spaceship/v0.1.1)
+
+* [#144](https://github.com/ignite/apps/pull/144) Spaceship faucet
+* [#145](https://github.com/ignite/apps/pull/145) Improve logs
+
 ## [`v0.1.0`](https://github.com/ignite/apps/releases/tag/spaceship/v0.1.0)
 
 * First release of the Spaceship app compatible with Ignite >= v28.x.y

--- a/spaceship/README.md
+++ b/spaceship/README.md
@@ -12,10 +12,10 @@ Spaceship is an Ignite App designed to extend the [Ignite CLI](https://github.co
 Spaceship provides multiple ways to connect to your SSH server for deployment:
 
 ```sh
-ignite spaceship deploy root@127.0.0.1 --key $HOME/.ssh/id_rsa
-ignite spaceship deploy 127.0.0.1 --user root --key $HOME/.ssh/id_rsa
-ignite spaceship deploy 127.0.0.1 --user root --password password
-ignite spaceship deploy root@127.0.0.1 --key $HOME/.ssh/id_rsa --key-password key_password
+ignite spaceship deploy <user>@<ip-address> --key $HOME/.ssh/id_rsa
+ignite spaceship deploy <ip-address> --user root --key $HOME/.ssh/id_rsa
+ignite spaceship deploy <ip-address> --user root --password password
+ignite spaceship deploy <user>@<ip-address> --key $HOME/.ssh/id_rsa --key-password key_password
 ```
 
 Each command initiates a build of the blockchain binary and sets up the chain's home directory based on the configuration. The app then connects to the specified SSH server, establishes workspaces, transfers the binary, and executes it using a runner script.
@@ -34,31 +34,31 @@ To manage your blockchain deployment, use the following commands:
 - **Check status**:
 
 ```sh
-ignite spaceship status root@<ip-address> --key $HOME/.ssh/id_rsa
+ignite spaceship status <user>@<ip-address> --key $HOME/.ssh/id_rsa
 ```
 
 - **View logs**:
 
 ```sh
-ignite spaceship log root@<ip-address> --key $HOME/.ssh/id_rsa
+ignite spaceship log <user>@<ip-address> --key $HOME/.ssh/id_rsa
 ```
 
 - **Watch the logs in real time**:
 
 ```sh
-ignite spaceship log root@<ip-address> --key $HOME/.ssh/id_rsa --real-time
+ignite spaceship log <user>@<ip-address> --key $HOME/.ssh/id_rsa --real-time
 ```
 
 - **Restart the chain**:
 
 ```sh
-ignite spaceship restart root@<ip-address> --key $HOME/.ssh/id_rsa
+ignite spaceship restart <user>@<ip-address> --key $HOME/.ssh/id_rsa
 ```
 
 - **Stop the chain**:
 
 ```sh
-ignite spaceship stop root@<ip-address> --key $HOME/.ssh/id_rsa
+ignite spaceship stop <user>@<ip-address> --key $HOME/.ssh/id_rsa
 ```
 
 To redeploy the chain on the same server without overwriting the home directory, use the `--init-chain` flag to reinitialize the chain if necessary.
@@ -68,19 +68,19 @@ To redeploy the chain on the same server without overwriting the home directory,
 You can deploy your chain along with a faucet application by passing the faucet flag to the deploy command:
 
 ```sh
-ignite spaceship deploy root@127.0.0.1 --key $HOME/.ssh/id_rsa --faucet
+ignite spaceship deploy <user>@<ip-address> --key $HOME/.ssh/id_rsa --faucet
 ```
 
 You can also specify the faucet port:
 
 ```sh
-ignite spaceship deploy root@127.0.0.1 --key $HOME/.ssh/id_rsa --faucet --faucet-port 8077
+ignite spaceship deploy <user>@<ip-address> --key $HOME/.ssh/id_rsa --faucet --faucet-port 8077
 ```
 
 To check the faucet logs, pass the parameter `faucet` to the `--app` flag in the log command:
 
 ```sh
-ignite spaceship log root@127.0.0.1 --key $HOME/.ssh/id_rsa --app faucet
+ignite spaceship log <user>@<ip-address> --key $HOME/.ssh/id_rsa --app faucet
 ```
 
 ### Config

--- a/spaceship/README.md
+++ b/spaceship/README.md
@@ -32,25 +32,34 @@ The workspaces are organized under `$HOME/workspace/<chain-id>` and include:
 To manage your blockchain deployment, use the following commands:
 
 - **Check status**:
-  ```sh
-  ignite spaceship status root@<ip-address> --key $HOME/.ssh/id_rsa
-  ```
+
+```sh
+ignite spaceship status root@<ip-address> --key $HOME/.ssh/id_rsa
+```
+
 - **View logs**:
-  ```sh
-  ignite spaceship log root@<ip-address> --key $HOME/.ssh/id_rsa
-  ```
+
+```sh
+ignite spaceship log root@<ip-address> --key $HOME/.ssh/id_rsa
+```
+
 - **Watch the logs in real time**:
-  ```sh
-  ignite spaceship log root@<ip-address> --key $HOME/.ssh/id_rsa --real-time
-  ```
+
+```sh
+ignite spaceship log root@<ip-address> --key $HOME/.ssh/id_rsa --real-time
+```
+
 - **Restart the chain**:
-  ```sh
-  ignite spaceship restart root@<ip-address> --key $HOME/.ssh/id_rsa
-  ```
+
+```sh
+ignite spaceship restart root@<ip-address> --key $HOME/.ssh/id_rsa
+```
+
 - **Stop the chain**:
-  ```sh
-  ignite spaceship stop root@<ip-address> --key $HOME/.ssh/id_rsa
-  ```
+
+```sh
+ignite spaceship stop root@<ip-address> --key $HOME/.ssh/id_rsa
+```
 
 To redeploy the chain on the same server without overwriting the home directory, use the `--init-chain` flag to reinitialize the chain if necessary.
 
@@ -58,13 +67,13 @@ To redeploy the chain on the same server without overwriting the home directory,
 
 You can deploy your chain along with a faucet application by passing the faucet flag to the deploy command:
 
-```ssh
+```sh
 ignite spaceship deploy root@127.0.0.1 --key $HOME/.ssh/id_rsa --faucet
 ```
 
 You can also specify the faucet port:
 
-```ssh
+```sh
 ignite spaceship deploy root@127.0.0.1 --key $HOME/.ssh/id_rsa --faucet --faucet-port 8077
 ```
 

--- a/spaceship/README.md
+++ b/spaceship/README.md
@@ -66,6 +66,26 @@ ignite spaceship stop root@127.0.0.1 --key $HOME/.ssh/id_rsa
 To redeploy the chain on the same server without overwriting the home directory, use the `--init-chain` flag to
 reinitialize the chain if necessary.
 
+## Faucet
+
+You  can deploy your chain along with a faucet application passing the faucet flag to the deploy command
+
+```ssh
+ignite spaceship deploy root@127.0.0.1 --key $HOME/.ssh/id_rsa --faucet
+```
+
+and also specify the faucet port:
+
+```ssh
+ignite spaceship deploy root@127.0.0.1 --key $HOME/.ssh/id_rsa --faucet --faucet-port 8077
+```
+
+To check the faucet logs, pass the parameter `faucet` to the `--app` flag into the log command:
+
+```sh
+ignite spaceship log root@127.0.0.1 --key $HOME/.ssh/id_rsa --app faucet
+```
+
 ### Config
 
 You can override the default [chain configuration](https://docs.ignite.com/references/config#validators) by using the

--- a/spaceship/README.md
+++ b/spaceship/README.md
@@ -1,12 +1,11 @@
 # Spaceship
 
-Spaceship is an Ignite App designed to extend the [Ignite CLI](https://github.com/ignite/cli) by providing tools to
-deploy blockchain applications via SSH.
+Spaceship is an Ignite App designed to extend the [Ignite CLI](https://github.com/ignite/cli) by providing tools to deploy blockchain applications via SSH.
 
 ## Prerequisites
 
-* Ignite CLI: Version `v28.4.0` or higher is required.
-* Blockchain Scaffold: A blockchain scaffolded using Ignite
+* **Ignite CLI**: Version `v28.4.0` or higher is required.
+* **Blockchain Scaffold**: A blockchain scaffolded using Ignite.
 
 ## Usage
 
@@ -19,68 +18,57 @@ ignite spaceship deploy 127.0.0.1 --user root --password password
 ignite spaceship deploy root@127.0.0.1 --key $HOME/.ssh/id_rsa --key-password key_password
 ```
 
-Each command initiates a build of the blockchain binary and sets up the chain's home directory based on the
-configuration. The app then connects to the specified SSH server, establishes workspaces, transfers the binary, and
-executes it using a runner script. The workspaces are organized under `$HOME/workspace/<chain-id>` and include:
+Each command initiates a build of the blockchain binary and sets up the chain's home directory based on the configuration. The app then connects to the specified SSH server, establishes workspaces, transfers the binary, and executes it using a runner script.
 
-- Binary Directory: `$HOME/workspace/<chain-id>/bin` - Contains the chain binary.
-- Home Directory: `$HOME/workspace/<chain-id>/home` - Stores chain data.
-- Log Directory: `$HOME/workspace/<chain-id>/log` - Holds logs of the running chain.
-- Runner Script: `$HOME/workspace/<chain-id>/run.sh` - A script to start the binary in the background using nohup.
-- PID File: `$HOME/workspace/<chain-id>/spaceship.pid` - Stores the PID of the currently running chain instance.
+The workspaces are organized under `$HOME/workspace/<chain-id>` and include:
+- **Binary Directory**: `$HOME/workspace/<chain-id>/bin` - Contains the chain binary.
+- **Home Directory**: `$HOME/workspace/<chain-id>/home` - Stores chain data.
+- **Log Directory**: `$HOME/workspace/<chain-id>/log` - Holds logs of the running chain.
+- **Runner Script**: `$HOME/workspace/<chain-id>/run.sh` - A script to start the binary in the background using `nohup`.
+- **PID File**: `$HOME/workspace/<chain-id>/spaceship.pid` - Stores the PID of the currently running chain instance.
 
 ### Managing the Chain
 
 To manage your blockchain deployment, use the following commands:
 
-- Check status:
+- **Check status**:
+  ```sh
+  ignite spaceship status root@<ip-address> --key $HOME/.ssh/id_rsa
+  ```
+- **View logs**:
+  ```sh
+  ignite spaceship log root@<ip-address> --key $HOME/.ssh/id_rsa
+  ```
+- **Watch the logs in real time**:
+  ```sh
+  ignite spaceship log root@<ip-address> --key $HOME/.ssh/id_rsa --real-time
+  ```
+- **Restart the chain**:
+  ```sh
+  ignite spaceship restart root@<ip-address> --key $HOME/.ssh/id_rsa
+  ```
+- **Stop the chain**:
+  ```sh
+  ignite spaceship stop root@<ip-address> --key $HOME/.ssh/id_rsa
+  ```
 
-```sh
-ignite spaceship status root@127.0.0.1 --key $HOME/.ssh/id_rsa
-```
-
-- View logs:
-
-```sh
-ignite spaceship log root@127.0.0.1 --key $HOME/.ssh/id_rsa
-```
-
-- Watch the logs in real time:
-
-```sh
-ignite spaceship log root@127.0.0.1 --key $HOME/.ssh/id_rsa --real-time
-```
-
-- Restart the chain:
-
-```sh
-ignite spaceship restart root@127.0.0.1 --key $HOME/.ssh/id_rsa
-```
-
-- Stop the Chain:
-
-```sh
-ignite spaceship stop root@127.0.0.1 --key $HOME/.ssh/id_rsa
-```
-
-To redeploy the chain on the same server without overwriting the home directory, use the `--init-chain` flag to
-reinitialize the chain if necessary.
+To redeploy the chain on the same server without overwriting the home directory, use the `--init-chain` flag to reinitialize the chain if necessary.
 
 ## Faucet
 
-You  can deploy your chain along with a faucet application passing the faucet flag to the deploy command
+You can deploy your chain along with a faucet application by passing the faucet flag to the deploy command:
 
 ```ssh
 ignite spaceship deploy root@127.0.0.1 --key $HOME/.ssh/id_rsa --faucet
 ```
 
-and also specify the faucet port:
+You can also specify the faucet port:
 
 ```ssh
 ignite spaceship deploy root@127.0.0.1 --key $HOME/.ssh/id_rsa --faucet --faucet-port 8077
 ```
 
-To check the faucet logs, pass the parameter `faucet` to the `--app` flag into the log command:
+To check the faucet logs, pass the parameter `faucet` to the `--app` flag in the log command:
 
 ```sh
 ignite spaceship log root@127.0.0.1 --key $HOME/.ssh/id_rsa --app faucet
@@ -88,16 +76,13 @@ ignite spaceship log root@127.0.0.1 --key $HOME/.ssh/id_rsa --app faucet
 
 ### Config
 
-You can override the default [chain configuration](https://docs.ignite.com/references/config#validators) by using the
-Ignite configuration file. Validators' node configuration files are stored in the data directory. By default, Spaceship
-initializes the chain locally in a temporary folder using the Ignite config file and then copies the configuration to
-the remote machine at `$HOME/workspace/<chain-id>/home`.
-Configuration resets are performed by Ignite when necessary, especially when using the `--init-chain` flag or if the chain
-was not previously initialized.
+You can override the default [chain configuration](https://docs.ignite.com/references/config#validators) by using the Ignite configuration file. Validators' node configuration files are stored in the data directory. By default, Spaceship initializes the chain locally in a temporary folder using the Ignite config file and then copies the configuration to the remote machine at `$HOME/workspace/<chain-id>/home`.
 
-Example Ignite config:
+Configuration resets are performed by Ignite when necessary, especially when using the `--init-chain` flag or if the chain was not previously initialized.
 
-```
+**Example Ignite config**:
+
+```yaml
 validators:
   - name: alice
     bonded: '100000000stake'

--- a/spaceship/cmd/chain.go
+++ b/spaceship/cmd/chain.go
@@ -20,6 +20,10 @@ import (
 	"github.com/ignite/apps/spaceship/templates/script"
 )
 
+const (
+	flagInitChain = "init-chain"
+)
+
 // ExecuteSSHStatus executes the ssh status subcommand.
 func ExecuteSSHStatus(ctx context.Context, cmd *plugin.ExecutedCommand, chain *plugin.ChainInfo) error {
 	session := cliui.New(cliui.StartSpinnerWithText(statusConnecting))

--- a/spaceship/cmd/cmd.go
+++ b/spaceship/cmd/cmd.go
@@ -1,6 +1,13 @@
 package cmd
 
-import "github.com/ignite/cli/v28/ignite/services/plugin"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ignite/cli/v28/ignite/services/plugin"
+
+	"github.com/ignite/apps/spaceship/pkg/ssh"
+)
 
 var defaultFlags = []*plugin.Flag{
 	{
@@ -73,44 +80,30 @@ func GetCommands() []*plugin.Command {
 				{
 					Use:   "log [host]",
 					Short: "get remote logs",
-					Commands: []*plugin.Command{
-						{
-							Use:   "chain",
-							Short: "get chain logs if its running",
-							Flags: append(defaultFlags,
-								&plugin.Flag{
-									Name:         flagLines,
-									Shorthand:    "l",
-									Usage:        "number of lines of chain logs",
-									Type:         plugin.FlagTypeInt,
-									DefaultValue: "100",
-								},
-								&plugin.Flag{
-									Name:  flagRealTime,
-									Usage: "show the logs in the real time",
-									Type:  plugin.FlagTypeBool,
-								},
-							),
+					Flags: append(defaultFlags,
+						&plugin.Flag{
+							Name:         flagLines,
+							Shorthand:    "l",
+							Usage:        "number of lines of chain logs",
+							Type:         plugin.FlagTypeInt,
+							DefaultValue: "100",
 						},
-						{
-							Use:   "faucet",
-							Short: "get faucet logs if its running",
-							Flags: append(defaultFlags,
-								&plugin.Flag{
-									Name:         flagLines,
-									Shorthand:    "l",
-									Usage:        "number of lines of chain logs",
-									Type:         plugin.FlagTypeInt,
-									DefaultValue: "100",
-								},
-								&plugin.Flag{
-									Name:  flagRealTime,
-									Usage: "show the logs in the real time",
-									Type:  plugin.FlagTypeBool,
-								},
-							),
+						&plugin.Flag{
+							Name:  flagRealTime,
+							Usage: "show the logs in the real time",
+							Type:  plugin.FlagTypeBool,
 						},
-					},
+						&plugin.Flag{
+							Name:      flagAppLog,
+							Shorthand: "a",
+							Usage: fmt.Sprintf(
+								"the app to show the log (%s)",
+								strings.Join(ssh.LogTypes(), ","),
+							),
+							Type:         plugin.FlagTypeString,
+							DefaultValue: ssh.LogChain.String(),
+						},
+					),
 				},
 				{
 					Use:   "status [host]",

--- a/spaceship/cmd/debug/main.go
+++ b/spaceship/cmd/debug/main.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/ignite/cli/v28/ignite/services/plugin"
 
 	"github.com/ignite/apps/spaceship/cmd"
+	"github.com/ignite/apps/spaceship/pkg/ssh"
 )
 
 func main() {
@@ -72,24 +74,27 @@ func main() {
 			return
 		}
 	case "log":
-		c.Flags = append(c.Flags, &plugin.Flag{
-			Name:  "real-time",
-			Usage: "show the logs in the real time",
-			Type:  plugin.FlagTypeBool,
-			Value: "true",
-		})
-		switch args[2] {
-		case "chain":
-			if err := cmd.ExecuteChainSSHLog(ctx, c, chainInfo); err != nil {
-				fmt.Fprintln(os.Stderr, err)
-				return
-			}
-		case "faucet":
-			if err := cmd.ExecuteFaucetSSHLog(ctx, c, chainInfo); err != nil {
-				fmt.Fprintln(os.Stderr, err)
-				return
-			}
-			fmt.Fprintf(os.Stderr, "unknown log command: %s", args[2])
+		c.Flags = append(c.Flags,
+			&plugin.Flag{
+				Name:  "real-time",
+				Usage: "show the logs in the real time",
+				Type:  plugin.FlagTypeBool,
+				Value: "true",
+			},
+			&plugin.Flag{
+				Name:      "app",
+				Shorthand: "a",
+				Usage: fmt.Sprintf(
+					"the app to show the log (%s)",
+					strings.Join(ssh.LogTypes(), ","),
+				),
+				Type:         plugin.FlagTypeString,
+				DefaultValue: ssh.LogChain.String(),
+				Value:        ssh.LogChain.String(),
+			},
+		)
+		if err := cmd.ExecuteSSHLog(ctx, c, chainInfo); err != nil {
+			fmt.Fprintln(os.Stderr, err)
 			return
 		}
 	case "status":

--- a/spaceship/cmd/faucet.go
+++ b/spaceship/cmd/faucet.go
@@ -9,6 +9,11 @@ import (
 	"github.com/ignite/cli/v28/ignite/services/plugin"
 )
 
+const (
+	flagFaucet     = "faucet"
+	flagFaucetPort = "faucet-port"
+)
+
 func faucetPort(f []*plugin.Flag) (uint64, error) {
 	flags := plugin.Flags(f)
 	port, err := flags.GetUint64(flagFaucetPort)

--- a/spaceship/cmd/log.go
+++ b/spaceship/cmd/log.go
@@ -11,16 +11,14 @@ import (
 	"github.com/ignite/apps/spaceship/pkg/ssh"
 )
 
-func ExecuteChainSSHLog(ctx context.Context, cmd *plugin.ExecutedCommand, chain *plugin.ChainInfo) error {
-	return ExecuteSSHLog(ctx, ssh.LogChain, cmd, chain)
-}
-
-func ExecuteFaucetSSHLog(ctx context.Context, cmd *plugin.ExecutedCommand, chain *plugin.ChainInfo) error {
-	return ExecuteSSHLog(ctx, ssh.LogFaucet, cmd, chain)
-}
+const (
+	flagLines    = "lines"
+	flagRealTime = "real-time"
+	flagAppLog   = "app"
+)
 
 // ExecuteSSHLog executes the ssh log subcommand.
-func ExecuteSSHLog(ctx context.Context, logType ssh.LogType, cmd *plugin.ExecutedCommand, chain *plugin.ChainInfo) error {
+func ExecuteSSHLog(ctx context.Context, cmd *plugin.ExecutedCommand, chain *plugin.ChainInfo) error {
 	session := cliui.New(cliui.StartSpinnerWithText(statusConnecting))
 	defer session.End()
 
@@ -28,7 +26,13 @@ func ExecuteSSHLog(ctx context.Context, logType ssh.LogType, cmd *plugin.Execute
 		flags       = plugin.Flags(cmd.Flags)
 		lines, _    = flags.GetInt(flagLines)
 		realTime, _ = flags.GetBool(flagRealTime)
+		appLog, _   = flags.GetString(flagAppLog)
 	)
+
+	logType, err := ssh.ParseLogType(appLog)
+	if err != nil {
+		return err
+	}
 
 	c, err := executeSSH(cmd, chain)
 	if err != nil {

--- a/spaceship/cmd/ssh.go
+++ b/spaceship/cmd/ssh.go
@@ -16,11 +16,6 @@ const (
 	flagKey         = "key"
 	flagRawKey      = "raw-key"
 	flagKeyPassword = "key-password"
-	flagInitChain   = "init-chain"
-	flagFaucet      = "faucet"
-	flagFaucetPort  = "faucet-port"
-	flagLines       = "lines"
-	flagRealTime    = "real-time"
 
 	statusConnecting = "Connecting..."
 )

--- a/spaceship/main.go
+++ b/spaceship/main.go
@@ -38,14 +38,7 @@ func (app) Execute(ctx context.Context, c *plugin.ExecutedCommand, api plugin.Cl
 	case "stop":
 		return cmd.ExecuteSSHSStop(ctx, c, chainInfo)
 	case "log":
-		switch args[1] {
-		case "chain":
-			return cmd.ExecuteChainSSHLog(ctx, c, chainInfo)
-		case "faucet":
-			return cmd.ExecuteFaucetSSHLog(ctx, c, chainInfo)
-		default:
-			return fmt.Errorf("unknown log command: %s", args[1])
-		}
+		return cmd.ExecuteSSHLog(ctx, c, chainInfo)
 	case "faucet":
 		switch args[1] {
 		case "status":

--- a/spaceship/pkg/ssh/log.go
+++ b/spaceship/pkg/ssh/log.go
@@ -30,9 +30,29 @@ type (
 const (
 	logExtension = ".log"
 
-	LogChain  LogType = "chain_"
-	LogFaucet LogType = "faucet_"
+	LogChain  LogType = "chain"
+	LogFaucet LogType = "faucet"
 )
+
+func (l LogType) String() string {
+	return string(l)
+}
+
+func LogTypes() []string {
+	return []string{LogChain.String(), LogFaucet.String()}
+}
+
+// ParseLogType parses the log type from a string.
+func ParseLogType(logType string) (LogType, error) {
+	switch LogType(strings.ToLower(logType)) {
+	case LogChain:
+		return LogChain, nil
+	case LogFaucet:
+		return LogFaucet, nil
+	default:
+		return "", errors.New("invalid log type: " + logType)
+	}
+}
 
 func (a logs) Len() int           { return len(a) }
 func (a logs) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }


### PR DESCRIPTION
## Description

- Improve readme;
- now we can pass a flag to the log command to check each app we want to see the logs to avoid creating a command to check the log for each app running;

### How to use

Chain logs:

```ssh
ignite spaceship log root@127.0.0.1 --key $HOME/.ssh/id_rsa --app chain
```

Faucet logs:

```ssh
ignite spaceship log root@127.0.0.1 --key $HOME/.ssh/id_rsa --app faucet
```

By default, it shows the log for the chain:

```ssh
ignite spaceship log root@127.0.0.1 --key $HOME/.ssh/id_rsa
```