### PR TITLE
chore: add network authors

### DIFF
--- a/network/AUTHORS
+++ b/network/AUTHORS
@@ -1,0 +1,12 @@
+# Authors
+
+This is a list of authors who have contributed to the project.
+Some co-authors are from the original project: [cli-plugin-network repo](https://github.com/ignite/cli-plugin-network)
+
+- Thomas Bruyelle (@tbruyelle)
+- Danilo Pantani (@Pantani)
+- Jerónimo Albi (@jeronimoalbi)
+- Alex (@aljo242)
+- Lucas Bertrand (@lumtis)
+- Denis Fadeev (@fadeev)
+- Julien Robert (@julienrbrt)


### PR DESCRIPTION
I merged https://github.com/ignite/apps/pull/19 without adding the co-authors to the commit.
As we shouldn't rewrite history, let's add an AUTHORS file in the folder, as it is often done in open source projects as well as an alternative.