### PR TITLE
Add CsClient app to registry

### DIFF
--- a/_registry/lxgr-linux.ignite-app-cs-client.cs-client.json
+++ b/_registry/lxgr-linux.ignite-app-cs-client.cs-client.json
@@ -1,0 +1,29 @@
+{
+  "appName": "CsClient",
+  "slug": "cs-client",
+  "appDescription": "Generates a C# client library for your cosmos-sdk blockchain",
+  "ignite": ">28.1.1",
+  "dependencies": {},
+  "cosmosSDK": ">0.50.4",
+  "authors": [
+    {
+      "name": "Peer Meyer",
+      "github": "lxgr-linux"
+    }
+  ],
+  "repositoryUrl": "https://github.com/lxgr-linux/ignite-app-cs-client",
+  "documentationUrl": "https://github.com/lxgr-linux/ignite-app-cs-client/blob/README.md",
+  "license": {
+    "name": "MIT",
+    "url": "https://github.com/lxgr-linux/ignite-app-cs-client/blob/main/LICENSE"
+  },
+  "donations": {
+    "cryptoAddresses": {
+      "cosmos": "cosmos1gzyygy4phl8ftjut6952psuz0gpajyt67zaccw"
+    }
+  },
+  "keywords": ["c#", "client", "cli", "cosmos-sdk", "ignite app"],
+  "supportedPlatforms": ["mac", "linux"],
+  "icon": "",
+  "cover": ""
+}

--- a/_registry/lxgr-linux.ignite-app-cs-client.cs-client.json
+++ b/_registry/lxgr-linux.ignite-app-cs-client.cs-client.json
@@ -8,7 +8,8 @@
   "authors": [
     {
       "name": "Peer Meyer",
-      "github": "lxgr-linux"
+      "github": "lxgr-linux",
+      "email": "lxgr@protonmail.com"
     }
   ],
   "repositoryUrl": "https://github.com/lxgr-linux/ignite-app-cs-client",


### PR DESCRIPTION
This adds the [CsClient](https://github.com/lxgr-linux/ignite-app-cs-client) app to the registry that "Generates a C# client library for your cosmos-sdk blockchain".

I also want to claim the app challenge bounty like mentioned [here](https://github.com/ignite/app_challenge/issues/1).

Feel free to comment on anything I might have overlooked.