### PR TITLE
refactor(rollkit): re-use `addModuleInitFlags`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,6 +3,15 @@
   - "!.github/labels.json"
   - .github/**/*
 
+"app:appregistry":
+  - appregistry/**/*
+
+"app:cca":
+  - cca/**/*
+
+"app:connect":
+  - connect/**/*
+
 "app:consumer":
   - consumer/**/*
 
@@ -12,11 +21,20 @@
 "app:explorer":
   - explorer/**/*
 
+"app:fee-abstraction":
+  - fee-abstraction/**/*
+
 "app:hermes":
   - hermes/**/*
 
-"app:appregistry":
-  - appregistry/**/*
+"app:network":
+  - network/**/*
+
+"app:rollkit":
+  - rollkit/**/*
+
+"app:spaceship":
+  - spaceship/**/*
 
 "app:wasm":
   - wasm/**/*

--- a/rollkit/CHANGELOG.md
+++ b/rollkit/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#112](https://github.com/ignite/apps/pull/112) Use default command instead cobra commands.
 * [#192](https://github.com/ignite/apps/pull/192) Upgrade Rollkit to `v1.x` and use [`go-execution-abci`](https://github.com/rollkit/go-execution-abci) instead of [`cosmos-sdk-starter`](https://github.com/rollkit/cosmos-sdk-starter).
   * Note, if you already have rollkit installed, you need to redo the wiring manually.
+* [#4666](https://github.com/ignite/cli/pull/4666) Uniform the flag addition with other apps.
 
 ## [`v0.2.1`](https://github.com/ignite/apps/releases/tag/rollkit/v0.2.1)
 

--- a/rollkit/CHANGELOG.md
+++ b/rollkit/CHANGELOG.md
@@ -7,7 +7,7 @@
 * [#112](https://github.com/ignite/apps/pull/112) Use default command instead cobra commands.
 * [#192](https://github.com/ignite/apps/pull/192) Upgrade Rollkit to `v1.x` and use [`go-execution-abci`](https://github.com/rollkit/go-execution-abci) instead of [`cosmos-sdk-starter`](https://github.com/rollkit/cosmos-sdk-starter).
   * Note, if you already have rollkit installed, you need to redo the wiring manually.
-* [#4666](https://github.com/ignite/cli/pull/4666) Uniform the flag addition with other apps.
+* [#194](https://github.com/ignite/apps/pull/194) Uniform the flag addition with other apps.
 
 ## [`v0.2.1`](https://github.com/ignite/apps/releases/tag/rollkit/v0.2.1)
 

--- a/rollkit/CHANGELOG.md
+++ b/rollkit/CHANGELOG.md
@@ -9,6 +9,14 @@
   * Note, if you already have rollkit installed, you need to redo the wiring manually.
 * [#194](https://github.com/ignite/apps/pull/194) Uniform the flag addition with other apps.
 
+## [`v0.2.3`](https://github.com/ignite/apps/releases/tag/rollkit/v0.2.3)
+
+* Dependency bumps
+
+## [`v0.2.2`](https://github.com/ignite/apps/releases/tag/rollkit/v0.2.2)
+
+* [#168](https://github.com/ignite/apps/pull/168) Update expected template.
+
 ## [`v0.2.1`](https://github.com/ignite/apps/releases/tag/rollkit/v0.2.1)
 
 * [#106](https://github.com/ignite/apps/pull/106) Improve bonded tokens setting.

--- a/rollkit/template/rollkit.go
+++ b/rollkit/template/rollkit.go
@@ -81,13 +81,20 @@ func commandsStartModify(appPath, binaryName string, version cosmosver.Version) 
 				"newApp",
 				"appExport",
 				`server.StartCmdOptions{
-				AddFlags: func(cmd *cobra.Command) {
-					abciserver.AddFlags(cmd)
-				},
+				AddFlags: addModuleInitFlags,
 				StartCommandHandler: abciserver.StartHandler(),
 			}`,
 			}, nil
 		})
+
+		// add the start command flags
+		content, err = xast.ModifyFunction(content,
+			"addModuleInitFlags",
+			xast.AppendFuncCode("abciserver.AddFlags(startCmd)"),
+		)
+		if err != nil {
+			return err
+		}
 
 		return r.File(genny.NewFileS(cmdPath, content))
 	}

--- a/wasm/CHANGELOG.md
+++ b/wasm/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* [#194](https://github.com/ignite/apps/pull/194) Prepare for the next release.
+
 ## [`v0.3.0`](https://github.com/ignite/apps/releases/tag/wasm/v0.3.0)
 
 * [#173](https://github.com/ignite/apps/pull/173) Bump wasm to `v0.54.0`

--- a/wasm/services/scaffolder/scaffolder.go
+++ b/wasm/services/scaffolder/scaffolder.go
@@ -43,14 +43,20 @@ func hasWasm(appPath string) bool {
 	if _, err := os.Stat(filepath.Join(appPath, "app/wasm.go")); err == nil {
 		return true
 	}
+
 	return false
 }
 
-// assertSupportedCosmosSDKVersion asserts that a Cosmos SDK version is supported by Ignite CLI.
+// assertSupportedCosmosSDKVersion asserts that a Cosmos SDK version is supported by the Wasm App.
 func assertSupportedCosmosSDKVersion(v cosmosver.Version) error {
+	if v.Semantic.GTE(semver.MustParse("0.53.0")) { // TODO: https://github.com/ignite/apps/issues/195
+		return errors.Errorf("Cosmos SDK version %s is not supported yet.", v)
+	}
+
 	if v.LT(cosmosver.StargateFiftyVersion) {
 		return errors.Errorf(errOldCosmosSDKVersionStr, v)
 	}
+
 	return nil
 }
 

--- a/wasm/services/scaffolder/scaffolder_test.go
+++ b/wasm/services/scaffolder/scaffolder_test.go
@@ -30,6 +30,7 @@ func Test_assertSupportedCosmosSDKVersion(t *testing.T) {
 		{
 			name: "Supported Cosmos SDK version (greater than)",
 			v:    v100,
+			err:  errors.Errorf("Cosmos SDK version %s is not supported yet.", v100),
 		},
 		{
 			name: "Unsupported Cosmos SDK version",

--- a/wasm/templates/wasm/wasm.go
+++ b/wasm/templates/wasm/wasm.go
@@ -137,11 +137,9 @@ ScopedWasmKeeper capabilitykeeper.ScopedKeeper
 
 		content, err = xast.ModifyFunction(content,
 			"New",
-			xast.NewFuncReturn(
-				"app",
-				"app.WasmKeeper.InitializePinnedCodes(app.NewUncachedContext(true, tmproto.Header{}))",
-			),
-		)
+			xast.AppendFuncCode(`if err := app.WasmKeeper.InitializePinnedCodes(app.NewUncachedContext(true, tmproto.Header{})); err != nil {
+		panic(err)
+	}`))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Same reasoning as https://github.com/ignite/cli/pull/4666. Makes the ignite rollkit and cosmwasm app play better together (https://github.com/ignite/apps/blob/main/wasm/templates/wasm/wasm.go#L226-L232)