### PR TITLE
fix: remove duplicated `v` alias for fee abstraction app

### DIFF
--- a/fee-abstraction/cmd/cmd.go
+++ b/fee-abstraction/cmd/cmd.go
@@ -63,7 +63,6 @@ func GetHooks() []*plugin.Hook {
 				{
 					Name:         flagVersion,
 					Usage:        "fee abstraction semantic version",
-					Shorthand:    "v",
 					DefaultValue: defaultFeeAbsVersion,
 					Type:         plugin.FlagTypeString,
 				},


### PR DESCRIPTION
```shell
panic: unable to redefine 'v' shorthand in "chain" flagset: it's already used for "fee-abstraction-version" flag

goroutine 1 [running]:
github.com/spf13/pflag.(*FlagSet).AddFlag(0x14000a62100, 0x14000a6dcc0)
	/Users/danilopantani/Desktop/go/pkg/mod/github.com/spf13/pflag@v1.0.6/flag.go:881 +0x378
github.com/spf13/cobra.(*Command).mergePersistentFlags.(*FlagSet).AddFlagSet.func2(0x14000a6dcc0)
	/Users/danilopantani/Desktop/go/pkg/mod/github.com/spf13/pflag@v1.0.6/flag.go:894 +0x44
github.com/spf13/pflag.(*FlagSet).VisitAll(0x14000a62000?, 0x14000a93b88)
	/Users/danilopantani/Desktop/go/pkg/mod/github.com/spf13/pflag@v1.0.6/flag.go:297 +0xdc
github.com/spf13/pflag.(*FlagSet).AddFlagSet(...)
	/Users/danilopantani/Desktop/go/pkg/mod/github.com/spf13/pflag@v1.0.6/flag.go:892
github.com/spf13/cobra.(*Command).mergePersistentFlags(0x140002e7b08)
	/Users/danilopantani/Desktop/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1896 +0x84
github.com/spf13/cobra.stripFlags({0x14000c046a0, 0x2, 0x2}, 0x140002e7b08)
	/Users/danilopantani/Desktop/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:678 +0x3c
github.com/spf13/cobra.(*Command).Find.func1(0x140002e7b08, {0x14000c046a0, 0x2, 0x2})
	/Users/danilopantani/Desktop/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:761 +0x48
github.com/spf13/cobra.(*Command).Find.func1(0x140002e7508, {0x14000a0a510, 0x3, 0x3})
	/Users/danilopantani/Desktop/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:769 +0xa8
github.com/spf13/cobra.(*Command).Find.func1(0x140002e7208, {0x1400004e060, 0x4, 0x4})
	/Users/danilopantani/Desktop/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:769 +0xa8
github.com/spf13/cobra.(*Command).Find(0x1027c3780?, {0x1400004e060?, 0x140005d3e08?, 0x10015efb4?})
	/Users/danilopantani/Desktop/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:774 +0x48
main.run()
	/Users/danilopantani/Desktop/go/src/github.com/ignite/cli/ignite/cmd/ignite/main.go:38 +0xf0
main.main()
	/Users/danilopantani/Desktop/go/src/github.com/ignite/cli/ignite/cmd/ignite/main.go:25 +0x1c
```