### PR TITLE
Add Notify App to Registry

### DIFF
--- a/_registry/QuenumGerald.notify.json
+++ b/_registry/QuenumGerald.notify.json
@@ -22,11 +22,11 @@
   "icon": "https://github.com/QuenumGerald/notify/blob/main/logo_notify.png",
   "cover": "https://github.com/QuenumGerald/notify/blob/main/banniere_notify.png",
   "socialMedia": {
-    "x": "",
-    "telegram": "",
-    "discord": "",
+    "x": "@MachineNova",
+    "telegram": "@NanoRick",
+    "discord": "novathemachine.",
     "reddit": "",
-    "website": ""
+    "website": "https://geraldquenum.netlify.app/"
   },
   "donations": {
     "cryptoAddresses": {},

--- a/_registry/QuenumGerald.notify.json
+++ b/_registry/QuenumGerald.notify.json
@@ -1,0 +1,35 @@
+{
+  "appName": "Notify",
+  "appID": "notify",
+  "appDescription": "Real-time Blockchain Event Notification App for Ignite. Subscribe to on-chain events and receive notifications via Slack, Telegram, etc.",
+  "ignite": ">=0.28.2",
+  "dependencies": {},
+  "cosmosSDK": ">=0.50.13",
+  "authors": [
+    {
+      "name": "Gerald Quenum",
+      "github": "QuenumGerald"
+    }
+  ],
+  "repositoryUrl": "https://github.com/QuenumGerald/notify",
+  "documentationUrl": "https://github.com/QuenumGerald/notify/blob/main/README.md",
+  "license": {
+    "name": "MIT",
+    "url": "https://github.com/QuenumGerald/notify/blob/main/LICENSE"
+  },
+  "keywords": ["notify", "notifications", "events", "blockchain", "ignite app"],
+  "supportedPlatforms": ["mac", "linux"],
+  "icon": "https://github.com/QuenumGerald/notify/blob/main/logo_notify.png",
+  "cover": "https://github.com/QuenumGerald/notify/blob/main/banniere_notify.png",
+  "socialMedia": {
+    "x": "",
+    "telegram": "",
+    "discord": "",
+    "reddit": "",
+    "website": ""
+  },
+  "donations": {
+    "cryptoAddresses": {},
+    "fiatDonationLinks": []
+  }
+}


### PR DESCRIPTION
# Add Notify App to Registry
This PR closes the previous one , README issues have been fixed
## Description
This PR adds Notify, a real-time blockchain event notification app, to the Ignite apps registry. Notify enables users to subscribe to on-chain events and receive notifications through various channels including Slack, Telegram, and more.

## Key Features
- Real-time blockchain event monitoring
- Customizable notifications via multiple channels (Slack, Telegram, etc.)
- Intuitive subscription management interface
- Compatible with Cosmos SDK-based blockchains


## Testing Instructions
1. Install the app using Ignite CLI:
   ```bash
   ignite app install github.com/QuenumGerald/notify