### PR TITLE
chore(evolve): use tagged version

### DIFF
--- a/evolve/template/constants.go
+++ b/evolve/template/constants.go
@@ -10,11 +10,10 @@ const (
 
 const (
 	GoExecPackage = "github.com/evstack/ev-abci"
-	GoExecVersion = "v0.3.1-0.20250818181501-f014411689fd" // main until tag
+	GoExecVersion = "v0.3.1-0.20250818181501-f014411689fd"
 
 	EvNodePackage = "github.com/evstack/ev-node"
-	EvNodeVersion = "v1.0.0-beta.2.0.20250818133040-d096a24e7052" // main until tag
+	EvNodeVersion = "v1.0.0-beta.2.0.20250818133040-d096a24e7052"
 
-	EvNodeDaCmd     = "github.com/evstack/ev-node/da/cmd/local-da"
-	EvNodeDaVersion = "v1.0.0-beta.1"
+	EvNodeDaCmd = "github.com/evstack/ev-node/da/cmd/local-da"
 )


### PR DESCRIPTION
Bumps the evolve apps template to use tagged version (currently blocked, as there's no tagged version).
Once this is bumped and merged, we can tag evolve v4.0.0 app (users now need to use `@main`)