### PR TITLE
ci: fix labeler job

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,67 +1,51 @@
 "ci":
-  - changed-files:
-      - "!.github/labeler.yml"
-      - "!.github/labels.json"
-      - .github/**/*
+  - "!.github/labeler.yml"
+  - "!.github/labels.json"
+  - .github/**/*
 
 "app:appregistry":
-  - changed-files:
-      - appregistry/**/*
+  - appregistry/**/*
 
 "app:cca":
-  - changed-files:
-      - cca/**/*
+  - cca/**/*
 
 "app:connect":
-  - changed-files:
-      - connect/**/*
+  - connect/**/*
 
 "app:consumer":
-  - changed-files:
-      - consumer/**/*
+  - consumer/**/*
 
 "app:examples":
-  - changed-files:
-      - examples/**/*
+  - examples/**/*
 
 "app:explorer":
-  - changed-files:
-      - explorer/**/*
+  - explorer/**/*
 
 "app:fee-abstraction":
-  - changed-files:
-      - fee-abstraction/**/*
+  - fee-abstraction/**/*
 
 "app:hermes":
-  - changed-files:
-      - hermes/**/*
+  - hermes/**/*
 
 "app:network":
-  - changed-files:
-      - network/**/*
+  - network/**/*
 
 "app:evolve":
-  - changed-files:
-      - evolve/**/*
+  - evolve/**/*
 
 "app:spaceship":
-  - changed-files:
-      - spaceship/**/*
+  - spaceship/**/*
 
 "app:wasm":
-  - changed-files:
-      - wasm/**/*
+  - wasm/**/*
 
 "configs":
-  - changed-files:
-      - .gitignore
-      - .gitattributes
-      - .markdownlint.yaml
-      - .golangci.yml
-      - app.ignite.yml
-      - CODE_OF_CONDUCT.md
-      - CONTRIBUTING.md
-      - go.work.example
-      - LICENSE
-      - Makefile
-      - README.md
+  - .gitignore
+  - .golangci.yml
+  - app.ignite.yml
+  - CODE_OF_CONDUCT.md
+  - CONTRIBUTING.md
+  - go.work.example
+  - LICENSE
+  - Makefile
+  - README.md

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -39,6 +39,8 @@
 
 "configs":
   - .gitignore
+  - .gitattributes
+  - .markdownlint.yaml
   - .golangci.yml
   - app.ignite.yml
   - CODE_OF_CONDUCT.md

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,4 @@
 "ci":
-  - "!.github/labeler.yml"
-  - "!.github/labels.json"
   - .github/**/*
 
 "app:appregistry":

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -15,4 +15,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v4 # keep v4 due to unwanted behavior changes in later versions.


### PR DESCRIPTION
ref: https://github.com/ignite/apps/actions/runs/17064785989/job/48379339445?pr=223
Reverts https://github.com/ignite/apps/pull/216 and use v4 of labeler, is always worked for us, no need to bump it.

will be fixed after merged to main, as it uses the pull request target trigger.